### PR TITLE
[#2] Add vitest test suite (89 tests, 9 files)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,8 @@
       "devDependencies": {
         "@types/node": "^22.13.0",
         "tsup": "^8.3.6",
-        "typescript": "^5.7.3"
+        "typescript": "^5.7.3",
+        "vitest": "^3.2.4"
       },
       "engines": {
         "node": ">=18"
@@ -938,6 +939,24 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -953,6 +972,121 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/abitype": {
@@ -996,6 +1130,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/bundle-require": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-5.1.0.tgz",
@@ -1020,6 +1164,33 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -1082,6 +1253,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.6.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
@@ -1093,6 +1274,13 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1136,11 +1324,31 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1212,6 +1420,13 @@
         "node": ">=10"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -1241,6 +1456,13 @@
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1282,6 +1504,25 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/object-assign": {
@@ -1331,6 +1572,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1371,6 +1622,35 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/postcss-load-config": {
@@ -1485,6 +1765,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.7.6",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
@@ -1493,6 +1780,43 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/sucrase": {
@@ -1551,6 +1875,13 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
@@ -1573,6 +1904,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -1701,6 +2062,194 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ws": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "commander": "^13.1.0",
@@ -26,7 +28,8 @@
   "devDependencies": {
     "@types/node": "^22.13.0",
     "tsup": "^8.3.6",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   },
   "engines": {
     "node": ">=18"

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,0 +1,297 @@
+/**
+ * Tests for src/api.ts — HTTP client for DropCast API endpoints.
+ *
+ * Mocks global.fetch to test all API functions in isolation.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  resolveCast,
+  createCampaign,
+  registerCampaignWithRetry,
+  ApiError,
+} from '../src/api.js'
+import type { CreateCampaignPayload } from '../src/config.js'
+
+// ── Helpers ──
+
+function mockFetch(response: {
+  status: number
+  ok?: boolean
+  json?: unknown
+  statusText?: string
+}): void {
+  const ok = response.ok ?? (response.status >= 200 && response.status < 300)
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      status: response.status,
+      ok,
+      statusText: response.statusText ?? 'OK',
+      json: vi.fn().mockResolvedValue(response.json ?? {}),
+    }),
+  )
+}
+
+function mockFetchSequence(
+  responses: Array<{
+    status: number
+    ok?: boolean
+    json?: unknown
+    statusText?: string
+  }>,
+): void {
+  let callIndex = 0
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockImplementation(() => {
+      const r = responses[callIndex] ?? responses[responses.length - 1]
+      callIndex++
+      const ok = r.ok ?? (r.status >= 200 && r.status < 300)
+      return Promise.resolve({
+        status: r.status,
+        ok,
+        statusText: r.statusText ?? 'OK',
+        json: vi.fn().mockResolvedValue(r.json ?? {}),
+      })
+    }),
+  )
+}
+
+const STUB_PAYLOAD: CreateCampaignPayload = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  hostFid: 12345,
+  hostWalletAddress: '0x0000000000000000000000000000000000000000',
+  platform: 'farcaster',
+  requireFollow: true,
+  requireLike: false,
+  requireRecast: false,
+  requireQuote: false,
+  requireComment: false,
+  minFollowerCount: 0,
+  minNeynarScore: 0,
+  minQuotientScore: 0,
+  requireProSubscriber: false,
+  requireVerifiedOnly: false,
+  requireProfilePhoto: false,
+  minAccountAgeDays: 0,
+  tokenAddress: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB',
+  tokenSymbol: 'DR',
+  tokenDecimals: 18,
+  rewardType: 'pool_split',
+  totalAmount: '50000',
+  endsAt: '2026-03-10T00:00:00.000Z',
+  fundingTxHash: '0xabc123',
+  baseFeePaid: '0.001',
+}
+
+// ── Tests ──
+
+describe('resolveCast', () => {
+  beforeEach(() => {
+    vi.stubEnv('DROPCAST_API_BASE_URL', 'https://test.dropcast.xyz')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns parsed cast data on success', async () => {
+    const castData = {
+      hash: '0xdeadbeef',
+      author: { fid: 1, username: 'alice', display_name: 'Alice', pfp_url: 'https://img.example.com/alice.jpg' },
+      text: 'Hello world',
+      embeds: [],
+    }
+    mockFetch({ status: 200, json: { cast: castData } })
+
+    const result = await resolveCast('https://warpcast.com/alice/0xabc')
+
+    expect(result).toEqual(castData)
+    expect(fetch).toHaveBeenCalledOnce()
+    const callUrl = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][0] as string
+    expect(callUrl).toContain('/api/neynar/cast?url=')
+  })
+
+  it('throws ApiError on non-200 response', async () => {
+    mockFetch({
+      status: 404,
+      ok: false,
+      json: { error: 'Cast not found' },
+      statusText: 'Not Found',
+    })
+
+    await expect(resolveCast('https://warpcast.com/alice/0xbad')).rejects.toThrow(ApiError)
+    await expect(resolveCast('https://warpcast.com/alice/0xbad')).rejects.toThrow(/Failed to resolve cast/)
+  })
+})
+
+describe('createCampaign', () => {
+  beforeEach(() => {
+    vi.stubEnv('DROPCAST_API_BASE_URL', 'https://test.dropcast.xyz')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('returns success with status 200 (idempotent)', async () => {
+    const responseData = {
+      success: true,
+      campaign: { id: STUB_PAYLOAD.id, campaign_number: 42, status: 'active' },
+    }
+    mockFetch({ status: 200, json: responseData })
+
+    const result = await createCampaign(STUB_PAYLOAD)
+
+    expect(result.status).toBe(200)
+    expect(result.data.campaign.campaign_number).toBe(42)
+  })
+
+  it('returns created with status 201', async () => {
+    const responseData = {
+      success: true,
+      campaign: { id: STUB_PAYLOAD.id, campaign_number: 99, status: 'pending' },
+    }
+    mockFetch({ status: 201, json: responseData })
+
+    const result = await createCampaign(STUB_PAYLOAD)
+
+    expect(result.status).toBe(201)
+    expect(result.data.campaign.id).toBe(STUB_PAYLOAD.id)
+  })
+
+  it('throws ApiError on 400 validation failure', async () => {
+    mockFetch({
+      status: 400,
+      ok: false,
+      json: { error: 'Missing required field: tokenAddress' },
+    })
+
+    await expect(createCampaign(STUB_PAYLOAD)).rejects.toThrow(ApiError)
+    try {
+      await createCampaign(STUB_PAYLOAD)
+    } catch (err) {
+      expect(err).toBeInstanceOf(ApiError)
+      expect((err as ApiError).status).toBe(400)
+    }
+  })
+})
+
+describe('registerCampaignWithRetry', () => {
+  beforeEach(() => {
+    vi.stubEnv('DROPCAST_API_BASE_URL', 'https://test.dropcast.xyz')
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('retries on 202 then succeeds on 201', async () => {
+    const successResponse = {
+      success: true,
+      campaign: { id: STUB_PAYLOAD.id, campaign_number: 55, status: 'active' },
+    }
+
+    // 202 twice, then 201
+    mockFetchSequence([
+      { status: 202, json: { success: false, campaign: {} } },
+      { status: 202, json: { success: false, campaign: {} } },
+      { status: 201, json: successResponse },
+    ])
+
+    const promise = registerCampaignWithRetry({ payload: STUB_PAYLOAD, json: true })
+
+    // Advance past first retry delay (2000ms)
+    await vi.advanceTimersByTimeAsync(2000)
+    // Advance past second retry delay (4000ms)
+    await vi.advanceTimersByTimeAsync(4000)
+
+    const result = await promise
+
+    expect(result.status).toBe(201)
+    expect(result.data.campaign.campaign_number).toBe(55)
+    expect(fetch).toHaveBeenCalledTimes(3)
+  })
+
+  it('throws immediately on 400 (no retry)', async () => {
+    mockFetch({
+      status: 400,
+      ok: false,
+      json: { error: 'Bad request' },
+    })
+
+    await expect(
+      registerCampaignWithRetry({ payload: STUB_PAYLOAD, json: true }),
+    ).rejects.toThrow(ApiError)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws immediately on 403 (no retry)', async () => {
+    mockFetch({
+      status: 403,
+      ok: false,
+      json: { error: 'Forbidden' },
+    })
+
+    await expect(
+      registerCampaignWithRetry({ payload: STUB_PAYLOAD, json: true }),
+    ).rejects.toThrow(ApiError)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws immediately on 409 (no retry)', async () => {
+    mockFetch({
+      status: 409,
+      ok: false,
+      json: { error: 'Conflict' },
+    })
+
+    await expect(
+      registerCampaignWithRetry({ payload: STUB_PAYLOAD, json: true }),
+    ).rejects.toThrow(ApiError)
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws after max retries when 202 is returned every time', async () => {
+    // Always return 202 — use mockFetchSequence with enough entries
+    const responses = Array.from({ length: 8 }, () => ({
+      status: 202,
+      json: { success: false, campaign: {} },
+    }))
+    mockFetchSequence(responses)
+
+    // Catch the promise immediately to prevent unhandled rejection
+    let caughtError: Error | undefined
+    const promise = registerCampaignWithRetry({ payload: STUB_PAYLOAD, json: true }).catch(
+      (err: Error) => {
+        caughtError = err
+      },
+    )
+
+    // There are 7 attempts total (0..6), with 6 delays between them:
+    // delays: 2000, 4000, 8000, 16000, 32000, 60000 = 122000ms total
+    // Advance enough time to cover all retries
+    for (let i = 0; i < 7; i++) {
+      await vi.advanceTimersByTimeAsync(65000) // generous advance per iteration
+    }
+
+    await promise
+
+    expect(caughtError).toBeDefined()
+    expect(caughtError!.message).toMatch(/pending finality after max retries/)
+    // 7 total attempts: initial + 6 retries
+    expect(fetch).toHaveBeenCalledTimes(7)
+  })
+})

--- a/tests/chain.test.ts
+++ b/tests/chain.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for src/chain.ts — On-chain operations with mocked viem clients.
+ *
+ * Mocks viem's createPublicClient and createWalletClient at the module level.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { formatEther, formatUnits } from 'viem'
+
+// ── Hoisted mock functions (must be declared before vi.mock) ──
+
+const {
+  mockReadContract,
+  mockSimulateContract,
+  mockGetBalance,
+  mockGetChainId,
+  mockWaitForTransactionReceipt,
+  mockSendTransaction,
+  mockWriteContract,
+} = vi.hoisted(() => ({
+  mockReadContract: vi.fn(),
+  mockSimulateContract: vi.fn(),
+  mockGetBalance: vi.fn(),
+  mockGetChainId: vi.fn(),
+  mockWaitForTransactionReceipt: vi.fn(),
+  mockSendTransaction: vi.fn(),
+  mockWriteContract: vi.fn(),
+}))
+
+vi.mock('viem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('viem')>()
+  return {
+    ...actual,
+    createPublicClient: vi.fn(() => ({
+      readContract: mockReadContract,
+      simulateContract: mockSimulateContract,
+      getBalance: mockGetBalance,
+      getChainId: mockGetChainId,
+      waitForTransactionReceipt: mockWaitForTransactionReceipt,
+    })),
+    createWalletClient: vi.fn(() => ({
+      sendTransaction: mockSendTransaction,
+      writeContract: mockWriteContract,
+      account: { address: '0x1111111111111111111111111111111111111111' },
+    })),
+  }
+})
+
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: vi.fn(() => ({
+    address: '0x1111111111111111111111111111111111111111' as const,
+  })),
+}))
+
+// Import AFTER mocks are set up
+import {
+  fundCampaign,
+  getBalances,
+  getRouterStats,
+  validateChainId,
+} from '../src/chain.js'
+
+// ── Tests ──
+
+describe('fundCampaign', () => {
+  beforeEach(() => {
+    vi.stubEnv('PRIVATE_KEY', '0x' + 'ab'.repeat(32))
+    vi.stubEnv('DROPCAST_ROUTER_ADDRESS', '0x' + 'ff'.repeat(20))
+    mockWaitForTransactionReceipt.mockResolvedValue({ status: 'success' })
+    mockSimulateContract.mockResolvedValue({ result: undefined })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    mockReadContract.mockReset()
+    mockSimulateContract.mockReset()
+    mockGetBalance.mockReset()
+    mockGetChainId.mockReset()
+    mockWaitForTransactionReceipt.mockReset()
+    mockSendTransaction.mockReset()
+    mockWriteContract.mockReset()
+  })
+
+  it('skips approval when allowance is sufficient', async () => {
+    // Allowance >= tokenAmount, so no approve needed
+    mockReadContract.mockResolvedValueOnce(1000000n) // allowance
+    mockSendTransaction.mockResolvedValueOnce('0xtxhash1') // fundCampaign tx
+    mockWriteContract.mockResolvedValueOnce('0xtxhash1') // alternative
+
+    const result = await fundCampaign({
+      tokenAddress: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB' as `0x${string}`,
+      tokenAmount: 500000n,
+      campaignId: '550e8400-e29b-41d4-a716-446655440000',
+      feeAmountWei: 1000000000000000n, // 0.001 ETH
+    })
+
+    expect(result.txHash).toBeDefined()
+    expect(result.approvalTxHash).toBeUndefined()
+    // Simulation should have been called
+    expect(mockSimulateContract).toHaveBeenCalledOnce()
+  })
+
+  it('approves first when allowance is insufficient', async () => {
+    // Allowance < tokenAmount
+    mockReadContract.mockResolvedValueOnce(100n) // allowance (too low)
+    // Approve tx
+    mockWriteContract.mockResolvedValueOnce('0xapprove_hash')
+    mockSendTransaction
+      .mockResolvedValueOnce('0xapprove_hash') // approve tx
+      .mockResolvedValueOnce('0xfund_hash') // fund tx
+
+    const result = await fundCampaign({
+      tokenAddress: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB' as `0x${string}`,
+      tokenAmount: 500000n,
+      campaignId: '550e8400-e29b-41d4-a716-446655440000',
+      feeAmountWei: 1000000000000000n,
+    })
+
+    expect(result.approvalTxHash).toBeDefined()
+    expect(result.txHash).toBeDefined()
+    // waitForTransactionReceipt should have been called (for approval at least)
+    expect(mockWaitForTransactionReceipt).toHaveBeenCalled()
+  })
+
+  it('propagates simulation failure without sending real tx', async () => {
+    mockReadContract.mockResolvedValueOnce(1000000n) // sufficient allowance
+    mockSimulateContract.mockRejectedValueOnce(new Error('InsufficientFee: sent 0, required 1000'))
+
+    await expect(
+      fundCampaign({
+        tokenAddress: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB' as `0x${string}`,
+        tokenAmount: 500000n,
+        campaignId: '550e8400-e29b-41d4-a716-446655440000',
+        feeAmountWei: 0n,
+      }),
+    ).rejects.toThrow(/InsufficientFee/)
+  })
+})
+
+describe('getBalances', () => {
+  afterEach(() => {
+    mockReadContract.mockReset()
+    mockGetBalance.mockReset()
+  })
+
+  it('returns formatted ETH and token balances', async () => {
+    const ethBal = 2000000000000000000n // 2 ETH
+    const tokenBal = 50000000000000000000000n // 50000 tokens (18 decimals)
+
+    mockGetBalance.mockResolvedValueOnce(ethBal)
+    mockReadContract.mockResolvedValueOnce(tokenBal)
+
+    const result = await getBalances(
+      '0x1111111111111111111111111111111111111111',
+      '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB',
+      18,
+    )
+
+    expect(result.ethBalance).toBe(ethBal)
+    expect(result.ethFormatted).toBe(formatEther(ethBal))
+    expect(result.tokenBalance).toBe(tokenBal)
+    expect(result.tokenFormatted).toBe(formatUnits(tokenBal, 18))
+  })
+})
+
+describe('getRouterStats', () => {
+  beforeEach(() => {
+    vi.stubEnv('DROPCAST_ROUTER_ADDRESS', '0x' + 'ff'.repeat(20))
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    mockReadContract.mockReset()
+  })
+
+  it('parses 5-element tuple correctly', async () => {
+    const tuple: [bigint, bigint, bigint, `0x${string}`, `0x${string}`] = [
+      42n, // totalCampaigns
+      5000000000000000n, // totalFeesCollected
+      1000000000000000n, // minBaseFee (0.001 ETH)
+      '0x2222222222222222222222222222222222222222', // buyBackBurner
+      '0x3333333333333333333333333333333333333333', // relayerWallet
+    ]
+    mockReadContract.mockResolvedValueOnce(tuple)
+
+    const stats = await getRouterStats()
+
+    expect(stats.totalCampaigns).toBe(42n)
+    expect(stats.totalFeesCollected).toBe(5000000000000000n)
+    expect(stats.minBaseFee).toBe(1000000000000000n)
+    expect(stats.minBaseFeeEth).toBe(formatEther(1000000000000000n))
+    expect(stats.buyBackBurner).toBe('0x2222222222222222222222222222222222222222')
+    expect(stats.relayerWallet).toBe('0x3333333333333333333333333333333333333333')
+  })
+})
+
+describe('validateChainId', () => {
+  afterEach(() => {
+    mockGetChainId.mockReset()
+  })
+
+  it('throws when chain ID does not match Base Mainnet', async () => {
+    mockGetChainId.mockResolvedValueOnce(1) // Ethereum Mainnet, not Base
+
+    await expect(validateChainId()).rejects.toThrow(/Expected Base Mainnet/)
+  })
+
+  it('does not throw when chain ID matches', async () => {
+    mockGetChainId.mockResolvedValueOnce(8453) // Base Mainnet
+
+    await expect(validateChainId()).resolves.toBeUndefined()
+  })
+})

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { campaignConfigSchema, buildCreatePayload, type CampaignConfig } from '../src/config.js'
+
+// ============================================
+// Helpers
+// ============================================
+
+const examplesDir = path.resolve(__dirname, '..', 'examples')
+
+function loadExample(filename: string): unknown {
+  const raw = fs.readFileSync(path.join(examplesDir, filename), 'utf-8')
+  return JSON.parse(raw)
+}
+
+/** Minimal valid farcaster fixed config for mutation tests. */
+function validFarcasterFixed(): Record<string, unknown> {
+  return {
+    network: 'base',
+    platform: 'farcaster',
+    host: {
+      fid: 1,
+      walletAddress: '0x0000000000000000000000000000000000000001',
+    },
+    post: { url: 'https://warpcast.com/alice/0xabc123' },
+    token: {
+      address: '0x0000000000000000000000000000000000000002',
+      symbol: 'TKN',
+      decimals: 18,
+    },
+    reward: {
+      type: 'fixed',
+      amountPerUser: '100',
+      maxParticipants: 10,
+    },
+    actions: {},
+    targeting: {},
+    schedule: { endsAt: '2026-04-01T00:00:00.000Z' },
+  }
+}
+
+// ============================================
+// Schema Validation
+// ============================================
+
+describe('campaignConfigSchema', () => {
+  describe('valid configs — example files', () => {
+    const examples = [
+      'campaign.farcaster.fixed.json',
+      'campaign.farcaster.pool-split.json',
+      'campaign.x.fixed.json',
+      'campaign.x.pool-split.json',
+    ]
+
+    for (const file of examples) {
+      it(`parses ${file} successfully`, () => {
+        const json = loadExample(file)
+        const result = campaignConfigSchema.safeParse(json)
+        expect(result.success).toBe(true)
+      })
+    }
+  })
+
+  describe('invalid — missing fields', () => {
+    it('fails when required top-level fields are missing', () => {
+      const result = campaignConfigSchema.safeParse({})
+      expect(result.success).toBe(false)
+    })
+
+    it('fails when host is missing fid', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.host as Record<string, unknown>).fid = undefined
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('invalid — bad addresses', () => {
+    it('rejects wallet address without 0x prefix', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.host as Record<string, unknown>).walletAddress =
+        'AAAA000000000000000000000000000000000001'
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects wallet address with wrong length', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.host as Record<string, unknown>).walletAddress = '0xDEAD'
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(false)
+    })
+
+    it('rejects token address with invalid hex', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.token as Record<string, unknown>).address = '0xGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGGG'
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('invalid — bad URLs', () => {
+    it('rejects invalid post URL', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.post as Record<string, unknown>).url = 'not-a-url'
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(false)
+    })
+  })
+
+  describe('invalid — wrong discriminated union', () => {
+    it('rejects pool_split with amountPerUser field', () => {
+      const cfg = validFarcasterFixed()
+      cfg.reward = {
+        type: 'pool_split',
+        totalAmount: '50000',
+        amountPerUser: '100', // invalid for pool_split
+      }
+      const result = campaignConfigSchema.safeParse(cfg)
+      // Zod strips unknown keys on discriminated unions, so this should
+      // parse but amountPerUser should NOT appear in the output.
+      if (result.success) {
+        expect((result.data.reward as Record<string, unknown>).amountPerUser).toBeUndefined()
+      }
+      // Either it fails or it strips — both acceptable
+    })
+  })
+
+  describe('defaults', () => {
+    it('applies correct defaults for omitted optional booleans', () => {
+      const cfg = validFarcasterFixed()
+      // actions and targeting left mostly empty to test defaults
+      cfg.actions = {}
+      cfg.targeting = {}
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(true)
+      if (!result.success) return
+
+      // Actions defaults
+      expect(result.data.actions.follow).toBe(true)
+      expect(result.data.actions.like).toBe(false)
+      expect(result.data.actions.recast).toBe(false)
+      expect(result.data.actions.quote).toBe(false)
+      expect(result.data.actions.comment).toBe(false)
+
+      // Targeting defaults
+      expect(result.data.targeting.requirePro).toBe(false)
+      expect(result.data.targeting.requireVerifiedOnly).toBe(false)
+      expect(result.data.targeting.requireProfilePhoto).toBe(false)
+      expect(result.data.targeting.minFollowers).toBe(0)
+      expect(result.data.targeting.minNeynarScore).toBe(0)
+      expect(result.data.targeting.minAccountAgeDays).toBe(0)
+    })
+  })
+
+  describe('boundary — decimals', () => {
+    it('accepts decimals = 0', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.token as Record<string, unknown>).decimals = 0
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(true)
+    })
+
+    it('accepts decimals = 77', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.token as Record<string, unknown>).decimals = 77
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(true)
+    })
+
+    it('rejects decimals = 78', () => {
+      const cfg = validFarcasterFixed()
+      ;(cfg.token as Record<string, unknown>).decimals = 78
+      const result = campaignConfigSchema.safeParse(cfg)
+      expect(result.success).toBe(false)
+    })
+  })
+})
+
+// ============================================
+// buildCreatePayload
+// ============================================
+
+describe('buildCreatePayload', () => {
+  /** Parse a valid config through the schema to get correct types + defaults. */
+  function parseConfig(overrides?: Partial<ReturnType<typeof validFarcasterFixed>>): CampaignConfig {
+    const raw = { ...validFarcasterFixed(), ...overrides }
+    const result = campaignConfigSchema.parse(raw)
+    return result
+  }
+
+  it('farcaster with castData — includes castHash and castUrl', () => {
+    const config = parseConfig()
+    const payload = buildCreatePayload({
+      campaignId: 'test-1',
+      config,
+      castData: {
+        hash: '0xdeadbeef',
+        authorFid: 99,
+        authorUsername: 'alice',
+        text: 'hello world',
+        imageUrl: null,
+      },
+      totalAmount: '1000',
+      fundingTxHash: '0xtx1',
+      baseFeePaid: '0.001',
+    })
+
+    expect(payload.castHash).toBe('0xdeadbeef')
+    expect(payload.castUrl).toBe(config.post.url)
+    expect(payload.castAuthorFid).toBe(99)
+    expect(payload.castAuthorUsername).toBe('alice')
+    expect(payload.platform).toBe('farcaster')
+    expect(payload.postUrl).toBeUndefined()
+  })
+
+  it('farcaster without castData — castHash is undefined', () => {
+    const config = parseConfig()
+    const payload = buildCreatePayload({
+      campaignId: 'test-2',
+      config,
+      totalAmount: '1000',
+      fundingTxHash: '0xtx2',
+      baseFeePaid: '0.001',
+    })
+
+    expect(payload.castHash).toBeUndefined()
+    expect(payload.castUrl).toBe(config.post.url)
+  })
+
+  it('X campaign — has postUrl, no castHash', () => {
+    const config = parseConfig({
+      platform: 'x',
+      post: { url: 'https://x.com/alice/status/123' },
+    })
+    const payload = buildCreatePayload({
+      campaignId: 'test-3',
+      config,
+      totalAmount: '1000',
+      fundingTxHash: '0xtx3',
+      baseFeePaid: '0.001',
+    })
+
+    expect(payload.postUrl).toBe('https://x.com/alice/status/123')
+    expect(payload.castHash).toBeUndefined()
+    expect(payload.castUrl).toBeUndefined()
+    expect(payload.platform).toBe('x')
+  })
+
+  it('fixed reward — amountPerUser and maxParticipants present', () => {
+    const config = parseConfig({
+      reward: { type: 'fixed', amountPerUser: '50', maxParticipants: 20 },
+    })
+    const payload = buildCreatePayload({
+      campaignId: 'test-4',
+      config,
+      totalAmount: '1000',
+      fundingTxHash: '0xtx4',
+      baseFeePaid: '0.001',
+    })
+
+    expect(payload.rewardType).toBe('fixed')
+    expect(payload.amountPerUser).toBe('50')
+    expect(payload.maxParticipants).toBe(20)
+  })
+
+  it('pool_split reward — totalAmount present, no amountPerUser', () => {
+    const config = parseConfig({
+      reward: { type: 'pool_split', totalAmount: '5000' },
+    })
+    const payload = buildCreatePayload({
+      campaignId: 'test-5',
+      config,
+      totalAmount: '5000',
+      fundingTxHash: '0xtx5',
+      baseFeePaid: '0.001',
+    })
+
+    expect(payload.rewardType).toBe('pool_split')
+    expect(payload.totalAmount).toBe('5000')
+    expect(payload.amountPerUser).toBeUndefined()
+    expect(payload.maxParticipants).toBeUndefined()
+  })
+})

--- a/tests/constants.test.ts
+++ b/tests/constants.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { campaignIdToBytes32, getRouterAddress, DEFAULT_ROUTER_ADDRESS } from '../src/constants.js'
+
+describe('campaignIdToBytes32', () => {
+  it('converts a standard UUID to hex bytes32', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    const result = campaignIdToBytes32(uuid)
+    // Dashes removed: 550e8400e29b41d4a716446655440000 (32 hex chars) padded to 64
+    expect(result).toBe('0x550e8400e29b41d4a71644665544000000000000000000000000000000000000')
+  })
+
+  it('pads shorter input to 32 bytes (64 hex chars)', () => {
+    const short = 'abcd'
+    const result = campaignIdToBytes32(short)
+    expect(result).toBe('0x' + 'abcd'.padEnd(64, '0'))
+  })
+
+  it('returns result starting with 0x and 66 chars total', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    const result = campaignIdToBytes32(uuid)
+    expect(result).toMatch(/^0x[0-9a-fA-F]{64}$/)
+    expect(result.length).toBe(66)
+  })
+})
+
+describe('getRouterAddress', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns DEFAULT_ROUTER_ADDRESS when no env var is set', () => {
+    vi.stubEnv('DROPCAST_ROUTER_ADDRESS', '')
+    const addr = getRouterAddress()
+    expect(addr).toBe(DEFAULT_ROUTER_ADDRESS)
+  })
+
+  it('returns env var value when DROPCAST_ROUTER_ADDRESS is set', () => {
+    const customAddr = '0x1234567890abcdef1234567890abcdef12345678'
+    vi.stubEnv('DROPCAST_ROUTER_ADDRESS', customAddr)
+    const addr = getRouterAddress()
+    expect(addr).toBe(customAddr)
+  })
+})

--- a/tests/create.test.ts
+++ b/tests/create.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for src/create.ts — createCommand integration tests.
+ *
+ * Mocks chain, api, resume, and config modules.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── Hoisted mocks ──
+
+const {
+  mockResolveCast,
+  mockGetTokenPrice,
+  mockRegisterCampaignWithRetry,
+  MockApiError,
+  mockGetBalances,
+  mockGetRouterStats,
+  mockFundCampaign,
+  mockValidateChainId,
+  mockGetWalletClient,
+  mockWriteRecoveryFile,
+  mockDeleteRecoveryFile,
+} = vi.hoisted(() => {
+  class MockApiError extends Error {
+    status: number
+    body: unknown
+    constructor(status: number, body: unknown, message: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+      this.body = body
+    }
+  }
+  return {
+    mockResolveCast: vi.fn(),
+    mockGetTokenPrice: vi.fn(),
+    mockRegisterCampaignWithRetry: vi.fn(),
+    MockApiError,
+    mockGetBalances: vi.fn(),
+    mockGetRouterStats: vi.fn(),
+    mockFundCampaign: vi.fn(),
+    mockValidateChainId: vi.fn(),
+    mockGetWalletClient: vi.fn(),
+    mockWriteRecoveryFile: vi.fn(),
+    mockDeleteRecoveryFile: vi.fn(),
+  }
+})
+
+vi.mock('../src/api.js', () => ({
+  resolveCast: mockResolveCast,
+  getTokenPrice: mockGetTokenPrice,
+  registerCampaignWithRetry: mockRegisterCampaignWithRetry,
+  ApiError: MockApiError,
+}))
+
+vi.mock('../src/chain.js', () => ({
+  getBalances: mockGetBalances,
+  getRouterStats: mockGetRouterStats,
+  fundCampaign: mockFundCampaign,
+  validateChainId: mockValidateChainId,
+  getWalletClient: mockGetWalletClient,
+}))
+
+vi.mock('../src/resume.js', () => ({
+  writeRecoveryFile: mockWriteRecoveryFile,
+  deleteRecoveryFile: mockDeleteRecoveryFile,
+}))
+
+// Import after mocks
+import { createCommand } from '../src/create.js'
+
+const CONFIG_PATH = 'examples/campaign.farcaster.pool-split.json'
+
+// ── Default mock implementations ──
+
+function setupDefaultMocks() {
+  mockResolveCast.mockResolvedValue({
+    hash: '0xdeadbeef',
+    author: { fid: 1, username: 'alice', display_name: 'Alice', pfp_url: '' },
+    text: 'Hello world',
+    embeds: [],
+  })
+  mockGetTokenPrice.mockResolvedValue(0.05)
+  mockRegisterCampaignWithRetry.mockResolvedValue({
+    status: 201,
+    data: {
+      success: true,
+      campaign: { id: 'test-id', campaign_number: 42, status: 'active' },
+    },
+  })
+  mockGetBalances.mockResolvedValue({
+    ethBalance: 2000000000000000000n,
+    ethFormatted: '2.0',
+    tokenBalance: 100000000000000000000000n,
+    tokenFormatted: '100000.0',
+  })
+  mockGetRouterStats.mockResolvedValue({
+    totalCampaigns: 10n,
+    totalFeesCollected: 500000000000000n,
+    minBaseFee: 1000000000000n, // very small, should always pass
+    minBaseFeeEth: '0.000001',
+    buyBackBurner: '0x' + '00'.repeat(20),
+    relayerWallet: '0x' + '00'.repeat(20),
+  })
+  mockFundCampaign.mockResolvedValue({
+    txHash: '0xfundingtxhash',
+    approvalTxHash: undefined,
+  })
+  mockValidateChainId.mockResolvedValue(undefined)
+  mockGetWalletClient.mockReturnValue({
+    account: { address: '0x0000000000000000000000000000000000000000' },
+    walletClient: {},
+  })
+  mockWriteRecoveryFile.mockReturnValue('.dropcast-cli/test-id.json')
+  mockDeleteRecoveryFile.mockReturnValue(undefined)
+}
+
+// ── Tests ──
+
+describe('createCommand', () => {
+  const originalExit = process.exit
+
+  beforeEach(() => {
+    // Make process.exit throw to actually halt execution (like real process.exit)
+    process.exit = vi.fn().mockImplementation((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never
+    // Reset and set up all mocks fresh for each test
+    vi.clearAllMocks()
+    setupDefaultMocks()
+  })
+
+  afterEach(() => {
+    process.exit = originalExit
+  })
+
+  it('dry-run works without PRIVATE_KEY', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await createCommand({
+      config: CONFIG_PATH,
+      json: false,
+    })
+
+    // Should print dry-run output, not throw
+    const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n')
+    expect(output).toContain('DRY RUN complete')
+    expect(mockFundCampaign).not.toHaveBeenCalled()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('dry-run --json outputs valid JSON only', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await createCommand({
+      config: CONFIG_PATH,
+      json: true,
+    })
+
+    // Should output exactly one JSON blob
+    expect(consoleSpy).toHaveBeenCalledTimes(1)
+    const jsonStr = consoleSpy.mock.calls[0][0] as string
+    const parsed = JSON.parse(jsonStr)
+    expect(parsed.mode).toBe('dry-run')
+    expect(parsed.campaignId).toBeDefined()
+    expect(parsed.fee).toBeDefined()
+    expect(parsed.totalAmount).toBeDefined()
+
+    consoleSpy.mockRestore()
+  })
+
+  it('execute exits on wallet mismatch', async () => {
+    // Make wallet client return a different address than config
+    mockGetWalletClient.mockReturnValueOnce({
+      account: { address: '0x9999999999999999999999999999999999999999' },
+      walletClient: {},
+    })
+
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await expect(
+      createCommand({
+        config: CONFIG_PATH,
+        execute: true,
+        yes: true,
+      }),
+    ).rejects.toThrow(/process\.exit\(1\)/)
+
+    expect(process.exit).toHaveBeenCalledWith(1)
+    expect(mockFundCampaign).not.toHaveBeenCalled()
+
+    vi.mocked(console.error).mockRestore?.()
+    vi.mocked(console.log).mockRestore?.()
+  })
+
+  it('execute succeeds: fund -> register -> success output', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await createCommand({
+      config: CONFIG_PATH,
+      execute: true,
+      yes: true,
+      json: true,
+    })
+
+    // Should call fund -> register -> cleanup
+    expect(mockFundCampaign).toHaveBeenCalledOnce()
+    expect(mockRegisterCampaignWithRetry).toHaveBeenCalledOnce()
+    expect(mockDeleteRecoveryFile).toHaveBeenCalledOnce()
+
+    // JSON output should include success
+    const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1]
+    const parsed = JSON.parse(lastCall[0] as string)
+    expect(parsed.success).toBe(true)
+    expect(parsed.campaignNumber).toBe(42)
+
+    consoleSpy.mockRestore()
+  })
+
+  it('execute writes recovery file and shows resume on API failure', async () => {
+    mockRegisterCampaignWithRetry.mockRejectedValueOnce(
+      new MockApiError(500, null, 'Server error'),
+    )
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await expect(
+      createCommand({
+        config: CONFIG_PATH,
+        execute: true,
+        yes: true,
+        json: true,
+      }),
+    ).rejects.toThrow(/process\.exit\(1\)/)
+
+    expect(mockFundCampaign).toHaveBeenCalledOnce()
+    expect(mockWriteRecoveryFile).toHaveBeenCalledOnce()
+    expect(process.exit).toHaveBeenCalledWith(1)
+
+    // JSON output should include recovery info
+    const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1]
+    const parsed = JSON.parse(lastCall[0] as string)
+    expect(parsed.error).toContain('Server error')
+    expect(parsed.recoveryFile).toBeDefined()
+
+    consoleSpy.mockRestore()
+    vi.mocked(console.error).mockRestore?.()
+  })
+
+  it('dry-run handles complete config with all fields', async () => {
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await createCommand({
+      config: CONFIG_PATH,
+      campaignId: '550e8400-e29b-41d4-a716-446655440000',
+      json: true,
+    })
+
+    const jsonStr = consoleSpy.mock.calls[0][0] as string
+    const parsed = JSON.parse(jsonStr)
+    expect(parsed.campaignId).toBe('550e8400-e29b-41d4-a716-446655440000')
+    expect(parsed.config.platform).toBe('farcaster')
+    expect(parsed.config.token.symbol).toBe('DR')
+
+    consoleSpy.mockRestore()
+  })
+})

--- a/tests/fees.test.ts
+++ b/tests/fees.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect } from 'vitest'
+import {
+  calculateFee,
+  getFeeBreakdown,
+  feeToWei,
+  formatFee,
+  isValidFee,
+  calculateQuotaSurcharge,
+  FEE_CONFIG,
+  type CampaignFeeOptions,
+} from '../src/fees.js'
+
+describe('calculateFee', () => {
+  it('returns base fee only when no actions or targeting', () => {
+    const fee = calculateFee({})
+    expect(fee).toBe(FEE_CONFIG.BASE) // 0.0010
+  })
+
+  it('sums all action fees plus base when all actions enabled', () => {
+    const fee = calculateFee({
+      requireLike: true,
+      requireRecast: true,
+      requireQuote: true,
+      requireComment: true,
+    })
+    const expected =
+      FEE_CONFIG.BASE +
+      FEE_CONFIG.LIKE +
+      FEE_CONFIG.RECAST +
+      FEE_CONFIG.QUOTE +
+      FEE_CONFIG.COMMENT
+    expect(fee).toBeCloseTo(expected, 10)
+  })
+
+  it('sums all targeting fees plus base when all targeting enabled', () => {
+    const fee = calculateFee({
+      minFollowers: 100,
+      minNeynarScore: 0.5,
+      minQuotientScore: 50,
+      requireProSubscriber: true,
+      requireVerifiedOnly: true,
+      requireProfilePhoto: true,
+      minAccountAgeDays: 30,
+      minXFollowers: 100,
+      baseVerifyProviderCount: 1,
+    })
+    const expected =
+      FEE_CONFIG.BASE +
+      FEE_CONFIG.MIN_FOLLOWERS +
+      FEE_CONFIG.MIN_NEYNAR_SCORE +
+      FEE_CONFIG.MIN_QUOTIENT_SCORE +
+      FEE_CONFIG.PRO_ONLY +
+      FEE_CONFIG.VERIFIED_ONLY +
+      FEE_CONFIG.PROFILE_PHOTO +
+      FEE_CONFIG.ACCOUNT_AGE +
+      FEE_CONFIG.X_MIN_FOLLOWERS +
+      FEE_CONFIG.BASE_VERIFY_PER_PROVIDER * 1
+    expect(fee).toBeCloseTo(expected, 10)
+  })
+
+  it('adds FIXED_REWARD surcharge when rewardType is fixed', () => {
+    const base = calculateFee({})
+    const withFixed = calculateFee({ rewardType: 'fixed' })
+    expect(withFixed).toBeCloseTo(base + FEE_CONFIG.FIXED_REWARD, 10)
+  })
+
+  it('adds X_CAMPAIGN surcharge when isXCampaign is true', () => {
+    const base = calculateFee({})
+    const withX = calculateFee({ isXCampaign: true })
+    expect(withX).toBeCloseTo(base + FEE_CONFIG.X_CAMPAIGN, 10)
+  })
+})
+
+describe('calculateQuotaSurcharge', () => {
+  it('returns tier 1 fee for eligibleCount 1-100', () => {
+    const result = calculateQuotaSurcharge(50)
+    expect(result.fee).toBe(0.0006)
+    expect(result.tierLabel).toBe('1-100')
+  })
+
+  it('returns tier 2 fee for eligibleCount 101-500', () => {
+    const result = calculateQuotaSurcharge(250)
+    expect(result.fee).toBe(0.0009)
+    expect(result.tierLabel).toBe('101-500')
+  })
+
+  it('returns tier 3 fee for eligibleCount 501-1500', () => {
+    const result = calculateQuotaSurcharge(1000)
+    expect(result.fee).toBe(0.0012)
+    expect(result.tierLabel).toBe('501-1500')
+  })
+
+  it('returns tier 4 fee for eligibleCount 1501-3000', () => {
+    const result = calculateQuotaSurcharge(2000)
+    expect(result.fee).toBe(0.0015)
+    expect(result.tierLabel).toBe('1501-3000')
+  })
+
+  it('returns tier 5 fee for eligibleCount 3001+', () => {
+    const result = calculateQuotaSurcharge(5000)
+    expect(result.fee).toBe(0.0018)
+    expect(result.tierLabel).toBe('3001+')
+  })
+
+  it('boundary: 100 is tier 1, 101 is tier 2', () => {
+    const at100 = calculateQuotaSurcharge(100)
+    const at101 = calculateQuotaSurcharge(101)
+    expect(at100.fee).toBe(0.0006)
+    expect(at100.tierLabel).toBe('1-100')
+    expect(at101.fee).toBe(0.0009)
+    expect(at101.tierLabel).toBe('101-500')
+  })
+
+  it('returns zero surcharge for eligibleCount 0', () => {
+    const result = calculateQuotaSurcharge(0)
+    expect(result.fee).toBe(0)
+    expect(result.tierLabel).toBeNull()
+  })
+
+  it('returns zero surcharge for null', () => {
+    const result = calculateQuotaSurcharge(null)
+    expect(result.fee).toBe(0)
+    expect(result.tierLabel).toBeNull()
+  })
+})
+
+describe('getFeeBreakdown', () => {
+  it('total matches calculateFee for the same options', () => {
+    const options: CampaignFeeOptions = {
+      requireLike: true,
+      requireRecast: true,
+      minFollowers: 50,
+      rewardType: 'fixed',
+      eligibleUserCount: 200,
+    }
+    const breakdown = getFeeBreakdown(options)
+    const fee = calculateFee(options)
+    expect(breakdown.total).toBeCloseTo(fee, 10)
+  })
+
+  it('returns correct labels and amounts in breakdown', () => {
+    const options: CampaignFeeOptions = {
+      requireLike: true,
+      requireComment: true,
+      minFollowers: 100,
+      eligibleUserCount: 50,
+    }
+    const breakdown = getFeeBreakdown(options)
+
+    expect(breakdown.base).toBe(FEE_CONFIG.BASE)
+    expect(breakdown.like).toBe(FEE_CONFIG.LIKE)
+    expect(breakdown.comment).toBe(FEE_CONFIG.COMMENT)
+    expect(breakdown.minFollowers).toBe(FEE_CONFIG.MIN_FOLLOWERS)
+    expect(breakdown.quotaSurcharge).toBe(0.0006)
+    expect(breakdown.quotaSurchargeTier).toBe('1-100')
+
+    // Disabled items should be 0
+    expect(breakdown.recast).toBe(0)
+    expect(breakdown.quote).toBe(0)
+    expect(breakdown.proOnly).toBe(0)
+    expect(breakdown.fixedReward).toBe(0)
+    expect(breakdown.xCampaign).toBe(0)
+  })
+})
+
+describe('feeToWei', () => {
+  it('converts 0.001 ETH to correct wei value', () => {
+    const wei = feeToWei(0.001)
+    expect(wei).toBe(1000000000000000n) // 10^15
+  })
+
+  it('converts small amount 0.0002 ETH to correct wei value', () => {
+    const wei = feeToWei(0.0002)
+    expect(wei).toBe(200000000000000n)
+  })
+})
+
+describe('formatFee', () => {
+  it('shows 4 decimal places for fee < 0.01', () => {
+    const result = formatFee(0.001)
+    expect(result).toBe('0.0010 ETH')
+  })
+
+  it('shows 3 decimal places for fee >= 0.01', () => {
+    const result = formatFee(0.05)
+    expect(result).toBe('0.050 ETH')
+  })
+
+  it('returns "0 ETH" for zero fee', () => {
+    expect(formatFee(0)).toBe('0 ETH')
+  })
+})
+
+describe('isValidFee', () => {
+  it('returns true when fee meets calculated minimum', () => {
+    const options: CampaignFeeOptions = { requireLike: true }
+    const minFee = calculateFee(options)
+    expect(isValidFee(minFee, options)).toBe(true)
+    expect(isValidFee(minFee + 0.001, options)).toBe(true)
+  })
+
+  it('returns false when fee is below calculated minimum', () => {
+    const options: CampaignFeeOptions = { requireLike: true }
+    const minFee = calculateFee(options)
+    expect(isValidFee(minFee - 0.0001, options)).toBe(false)
+  })
+})

--- a/tests/resume.command.test.ts
+++ b/tests/resume.command.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Tests for resumeCommand in src/resume.ts — command-level integration.
+ *
+ * Mocks fs (readFileSync/existsSync/unlinkSync) and api module.
+ * Since resumeCommand calls readRecoveryFile internally (same module),
+ * we mock the fs module to control what readRecoveryFile returns.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// ── Hoisted mocks ──
+
+const {
+  mockReadFileSync,
+  mockWriteFileSync,
+  mockMkdirSync,
+  mockUnlinkSync,
+  mockExistsSync,
+} = vi.hoisted(() => ({
+  mockReadFileSync: vi.fn(),
+  mockWriteFileSync: vi.fn(),
+  mockMkdirSync: vi.fn(),
+  mockUnlinkSync: vi.fn(),
+  mockExistsSync: vi.fn().mockReturnValue(true),
+}))
+
+const { mockRegisterCampaignWithRetry, mockResolveCast, MockApiError } = vi.hoisted(() => {
+  class MockApiError extends Error {
+    status: number
+    body: unknown
+    constructor(status: number, body: unknown, message: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+      this.body = body
+    }
+  }
+  return {
+    mockRegisterCampaignWithRetry: vi.fn(),
+    mockResolveCast: vi.fn(),
+    MockApiError,
+  }
+})
+
+vi.mock('fs', () => ({
+  readFileSync: mockReadFileSync,
+  writeFileSync: mockWriteFileSync,
+  mkdirSync: mockMkdirSync,
+  unlinkSync: mockUnlinkSync,
+  existsSync: mockExistsSync,
+}))
+
+vi.mock('../src/api.js', () => ({
+  resolveCast: mockResolveCast,
+  registerCampaignWithRetry: mockRegisterCampaignWithRetry,
+  ApiError: MockApiError,
+}))
+
+// Import AFTER mocks
+import { resumeCommand } from '../src/resume.js'
+
+// ── Fixtures ──
+
+function makeRecoveryData(overrides: Record<string, unknown> = {}) {
+  return {
+    campaignId: '550e8400-e29b-41d4-a716-446655440000',
+    fundingTxHash: '0xabc123def456',
+    baseFeePaid: '0.001',
+    config: {
+      network: 'base',
+      platform: 'farcaster',
+      host: {
+        fid: 12345,
+        walletAddress: '0x0000000000000000000000000000000000000000',
+      },
+      post: {
+        url: 'https://warpcast.com/alice/0xabc123',
+      },
+      token: {
+        address: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB',
+        symbol: 'DR',
+        decimals: 18,
+      },
+      reward: {
+        type: 'pool_split',
+        totalAmount: '50000',
+      },
+      actions: {
+        follow: true,
+        like: false,
+        recast: false,
+        quote: false,
+        comment: false,
+      },
+      targeting: {
+        minFollowers: 0,
+        minNeynarScore: 0,
+        minQuotientScore: 0,
+        requirePro: false,
+        requireVerifiedOnly: false,
+        requireProfilePhoto: false,
+        minAccountAgeDays: 0,
+        minXFollowers: 0,
+      },
+      schedule: {
+        endsAt: '2026-03-10T00:00:00.000Z',
+      },
+    },
+    createdAt: '2026-02-26T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+// ── Tests ──
+
+describe('resumeCommand', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    // Default: resolveCast succeeds
+    mockResolveCast.mockResolvedValue({
+      hash: '0xdeadbeef',
+      author: { fid: 1, username: 'alice', display_name: 'Alice', pfp_url: '' },
+      text: 'Hello world',
+      embeds: [],
+    })
+
+    // Default: register succeeds
+    mockRegisterCampaignWithRetry.mockResolvedValue({
+      status: 201,
+      data: {
+        success: true,
+        campaign: { id: 'test-id', campaign_number: 42, status: 'active' },
+      },
+    })
+
+    mockExistsSync.mockReturnValue(true)
+  })
+
+  it('successful resume: reads recovery -> registers -> deletes file', async () => {
+    const recovery = makeRecoveryData()
+    mockReadFileSync.mockReturnValue(JSON.stringify(recovery))
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await resumeCommand({ recovery: '.dropcast-cli/test.json', json: true })
+
+    expect(mockReadFileSync).toHaveBeenCalledWith('.dropcast-cli/test.json', 'utf-8')
+    expect(mockRegisterCampaignWithRetry).toHaveBeenCalledOnce()
+    // deleteRecoveryFile calls existsSync + unlinkSync
+    expect(mockUnlinkSync).toHaveBeenCalled()
+
+    // JSON output should show resumed: true
+    const lastCall = consoleSpy.mock.calls[consoleSpy.mock.calls.length - 1]
+    const parsed = JSON.parse(lastCall[0] as string)
+    expect(parsed.success).toBe(true)
+    expect(parsed.resumed).toBe(true)
+    expect(parsed.campaignNumber).toBe(42)
+
+    consoleSpy.mockRestore()
+  })
+
+  it('uses stored baseFeePaid when present', async () => {
+    const recovery = makeRecoveryData({ baseFeePaid: '0.0025' })
+    mockReadFileSync.mockReturnValue(JSON.stringify(recovery))
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await resumeCommand({ recovery: '.dropcast-cli/test.json', json: true })
+
+    // Check the payload sent to registerCampaignWithRetry
+    const call = mockRegisterCampaignWithRetry.mock.calls[0]
+    expect(call[0].payload.baseFeePaid).toBe('0.0025')
+
+    vi.mocked(console.log).mockRestore?.()
+  })
+
+  it('falls back to recalculation when baseFeePaid is not stored', async () => {
+    const recovery = makeRecoveryData()
+    delete (recovery as Record<string, unknown>).baseFeePaid
+    mockReadFileSync.mockReturnValue(JSON.stringify(recovery))
+
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await resumeCommand({ recovery: '.dropcast-cli/test.json', json: true })
+
+    // Payload should have a recalculated baseFeePaid
+    const call = mockRegisterCampaignWithRetry.mock.calls[0]
+    expect(call[0].payload.baseFeePaid).toBeDefined()
+    expect(typeof call[0].payload.baseFeePaid).toBe('string')
+    expect(parseFloat(call[0].payload.baseFeePaid)).toBeGreaterThan(0)
+
+    vi.mocked(console.log).mockRestore?.()
+  })
+
+  it('preserves recovery file on API failure', async () => {
+    const recovery = makeRecoveryData()
+    mockReadFileSync.mockReturnValue(JSON.stringify(recovery))
+
+    // Import the mocked ApiError to get the exact class reference
+    const { ApiError: ApiErrorClass } = await import('../src/api.js')
+    mockRegisterCampaignWithRetry.mockRejectedValueOnce(
+      new ApiErrorClass(500, null, 'Internal server error'),
+    )
+
+    const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    const originalExit = process.exit
+    process.exit = vi.fn().mockImplementation((code?: number) => {
+      throw new Error(`process.exit(${code})`)
+    }) as never
+
+    await expect(
+      resumeCommand({ recovery: '.dropcast-cli/test.json', json: true }),
+    ).rejects.toThrow(/process\.exit\(1\)/)
+
+    // Recovery file should NOT be deleted (unlinkSync should NOT be called)
+    expect(mockUnlinkSync).not.toHaveBeenCalled()
+    expect(process.exit).toHaveBeenCalledWith(1)
+
+    process.exit = originalExit
+    consoleSpy.mockRestore()
+    vi.mocked(console.error).mockRestore?.()
+  })
+
+  it('throws helpful error for missing recovery file', async () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('ENOENT')
+    })
+
+    await expect(
+      resumeCommand({ recovery: '/nonexistent/path.json' }),
+    ).rejects.toThrow(/Cannot read recovery file/)
+  })
+})

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Tests for src/resume.ts — Recovery file I/O functions.
+ *
+ * Uses real filesystem with temp directories.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { mkdtempSync, writeFileSync, existsSync, readFileSync } from 'fs'
+import { join } from 'path'
+import { tmpdir } from 'os'
+import {
+  writeRecoveryFile,
+  readRecoveryFile,
+  deleteRecoveryFile,
+  type RecoveryData,
+} from '../src/resume.js'
+
+// ── Fixtures ──
+
+const STUB_RECOVERY: RecoveryData = {
+  campaignId: '550e8400-e29b-41d4-a716-446655440000',
+  fundingTxHash: '0xabc123def456',
+  baseFeePaid: '0.001',
+  config: {
+    network: 'base',
+    platform: 'farcaster',
+    host: {
+      fid: 12345,
+      walletAddress: '0x0000000000000000000000000000000000000000',
+    },
+    post: {
+      url: 'https://warpcast.com/alice/0xabc123',
+    },
+    token: {
+      address: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB',
+      symbol: 'DR',
+      decimals: 18,
+    },
+    reward: {
+      type: 'pool_split',
+      totalAmount: '50000',
+    },
+    actions: {
+      follow: true,
+      like: false,
+      recast: false,
+      quote: false,
+      comment: false,
+    },
+    targeting: {
+      minFollowers: 0,
+      minNeynarScore: 0,
+      minQuotientScore: 0,
+      requirePro: false,
+      requireVerifiedOnly: false,
+      requireProfilePhoto: false,
+      minAccountAgeDays: 0,
+      minXFollowers: 0,
+    },
+    schedule: {
+      endsAt: '2026-03-10T00:00:00.000Z',
+    },
+  } as RecoveryData['config'],
+  createdAt: '2026-02-26T00:00:00.000Z',
+}
+
+describe('Recovery file I/O', () => {
+  let originalCwd: string
+  let tempDir: string
+
+  beforeEach(() => {
+    // Change cwd to a temp directory so .dropcast-cli/ is created there
+    originalCwd = process.cwd()
+    tempDir = mkdtempSync(join(tmpdir(), 'dropcast-test-'))
+    process.chdir(tempDir)
+  })
+
+  afterEach(() => {
+    process.chdir(originalCwd)
+  })
+
+  it('write + read roundtrip preserves data', () => {
+    const filePath = writeRecoveryFile(STUB_RECOVERY)
+
+    expect(existsSync(filePath)).toBe(true)
+
+    const recovered = readRecoveryFile(filePath)
+
+    expect(recovered.campaignId).toBe(STUB_RECOVERY.campaignId)
+    expect(recovered.fundingTxHash).toBe(STUB_RECOVERY.fundingTxHash)
+    expect(recovered.baseFeePaid).toBe(STUB_RECOVERY.baseFeePaid)
+    expect(recovered.config.platform).toBe('farcaster')
+    expect(recovered.config.token.symbol).toBe('DR')
+    expect(recovered.createdAt).toBe(STUB_RECOVERY.createdAt)
+  })
+
+  it('read throws for non-existent file', () => {
+    expect(() => readRecoveryFile('/nonexistent/path/recovery.json')).toThrow(
+      /Cannot read recovery file/,
+    )
+  })
+
+  it('read throws for corrupt JSON', () => {
+    const filePath = join(tempDir, 'corrupt.json')
+    writeFileSync(filePath, '{not valid json!!!', 'utf-8')
+
+    expect(() => readRecoveryFile(filePath)).toThrow(/Invalid JSON/)
+  })
+
+  it('read throws when required fields are missing', () => {
+    const filePath = join(tempDir, 'incomplete.json')
+    writeFileSync(
+      filePath,
+      JSON.stringify({ fundingTxHash: '0x123', config: {} }),
+      'utf-8',
+    )
+
+    expect(() => readRecoveryFile(filePath)).toThrow(/missing required fields/)
+  })
+
+  it('delete removes existing file and does not throw for non-existent', () => {
+    // Write a file first
+    writeRecoveryFile(STUB_RECOVERY)
+    const filePath = join('.dropcast-cli', `${STUB_RECOVERY.campaignId}.json`)
+    expect(existsSync(filePath)).toBe(true)
+
+    // Delete should succeed
+    deleteRecoveryFile(STUB_RECOVERY.campaignId)
+    expect(existsSync(filePath)).toBe(false)
+
+    // Delete again should not throw
+    expect(() => deleteRecoveryFile(STUB_RECOVERY.campaignId)).not.toThrow()
+
+    // Delete a totally random ID should not throw
+    expect(() => deleteRecoveryFile('nonexistent-id')).not.toThrow()
+  })
+})

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from 'vitest'
+import { buildFeeOptions } from '../src/validate.js'
+import type { CampaignConfig } from '../src/config.js'
+
+// ============================================
+// Helpers
+// ============================================
+
+/** Build a minimal CampaignConfig for testing buildFeeOptions. */
+function makeConfig(overrides: {
+  platform?: 'farcaster' | 'x'
+  actions?: Partial<CampaignConfig['actions']>
+  targeting?: Partial<CampaignConfig['targeting']>
+  reward?: CampaignConfig['reward']
+} = {}): CampaignConfig {
+  return {
+    network: 'base',
+    platform: overrides.platform ?? 'farcaster',
+    host: {
+      fid: 1,
+      walletAddress: '0x0000000000000000000000000000000000000001',
+    },
+    post: { url: 'https://warpcast.com/alice/0xabc123' },
+    token: {
+      address: '0x0000000000000000000000000000000000000002',
+      symbol: 'TKN',
+      decimals: 18,
+    },
+    reward: overrides.reward ?? {
+      type: 'pool_split' as const,
+      totalAmount: '1000',
+    },
+    actions: {
+      follow: true,
+      like: false,
+      recast: false,
+      quote: false,
+      comment: false,
+      ...overrides.actions,
+    },
+    targeting: {
+      minFollowers: 0,
+      minNeynarScore: 0,
+      minQuotientScore: 0,
+      requirePro: false,
+      requireVerifiedOnly: false,
+      requireProfilePhoto: false,
+      minAccountAgeDays: 0,
+      minXFollowers: 0,
+      baseVerifyTargeting: null,
+      ...overrides.targeting,
+    },
+    schedule: { endsAt: '2026-04-01T00:00:00.000Z' },
+  } as CampaignConfig
+}
+
+// ============================================
+// buildFeeOptions
+// ============================================
+
+describe('buildFeeOptions', () => {
+  describe('farcaster campaigns', () => {
+    it('actions pass through when true', () => {
+      const config = makeConfig({
+        platform: 'farcaster',
+        actions: { follow: true, like: true, recast: true },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.requireLike).toBe(true)
+      expect(opts.requireRecast).toBe(true)
+      expect(opts.isXCampaign).toBe(false)
+    })
+
+    it('actions pass through when false', () => {
+      const config = makeConfig({
+        platform: 'farcaster',
+        actions: { follow: false, like: false, recast: false, quote: false, comment: false },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.requireLike).toBe(false)
+      expect(opts.requireRecast).toBe(false)
+      expect(opts.requireQuote).toBe(false)
+      expect(opts.requireComment).toBe(false)
+      expect(opts.isXCampaign).toBe(false)
+    })
+  })
+
+  describe('X campaigns', () => {
+    it('forces all actions to false even when config has them true', () => {
+      const config = makeConfig({
+        platform: 'x',
+        actions: { follow: true, like: true, recast: true, quote: true, comment: true },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.isXCampaign).toBe(true)
+      expect(opts.requireLike).toBe(false)
+      expect(opts.requireRecast).toBe(false)
+      expect(opts.requireQuote).toBe(false)
+      expect(opts.requireComment).toBe(false)
+    })
+
+    it('P0-2 regression — explicitly true actions still forced false', () => {
+      const config = makeConfig({
+        platform: 'x',
+        actions: { follow: true, like: true, recast: true, quote: true, comment: true },
+      })
+      const opts = buildFeeOptions(config)
+
+      // Every engagement action must be false for X
+      expect(opts.requireLike).toBe(false)
+      expect(opts.requireRecast).toBe(false)
+      expect(opts.requireQuote).toBe(false)
+      expect(opts.requireComment).toBe(false)
+      expect(opts.isXCampaign).toBe(true)
+    })
+  })
+
+  describe('targeting values', () => {
+    it('passes through targeting values correctly', () => {
+      const config = makeConfig({
+        targeting: {
+          minFollowers: 100,
+          minNeynarScore: 0.8,
+          minQuotientScore: 50,
+          requirePro: true,
+          requireVerifiedOnly: true,
+          requireProfilePhoto: true,
+          minAccountAgeDays: 30,
+          minXFollowers: 500,
+        },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.minFollowers).toBe(100)
+      expect(opts.minNeynarScore).toBe(0.8)
+      expect(opts.minQuotientScore).toBe(50)
+      expect(opts.requireProSubscriber).toBe(true)
+      expect(opts.requireVerifiedOnly).toBe(true)
+      expect(opts.requireProfilePhoto).toBe(true)
+      expect(opts.minAccountAgeDays).toBe(30)
+      expect(opts.minXFollowers).toBe(500)
+    })
+  })
+
+  describe('reward type', () => {
+    it('detects fixed reward type', () => {
+      const config = makeConfig({
+        reward: { type: 'fixed', amountPerUser: '10', maxParticipants: 5 },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.rewardType).toBe('fixed')
+    })
+
+    it('detects pool_split reward type', () => {
+      const config = makeConfig({
+        reward: { type: 'pool_split', totalAmount: '5000' },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.rewardType).toBe('pool_split')
+    })
+  })
+
+  describe('Base Verify provider count', () => {
+    it('counts providers correctly', () => {
+      const config = makeConfig({
+        targeting: {
+          baseVerifyTargeting: {
+            coinbase: true,
+            attestation: true,
+            talent: true,
+          },
+        },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.baseVerifyProviderCount).toBe(3)
+    })
+
+    it('returns 0 when baseVerifyTargeting is null', () => {
+      const config = makeConfig({
+        targeting: { baseVerifyTargeting: null },
+      })
+      const opts = buildFeeOptions(config)
+
+      expect(opts.baseVerifyProviderCount).toBe(0)
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+    testTimeout: 10_000,
+  },
+})


### PR DESCRIPTION
## Summary
- Set up vitest with node environment, `test` and `test:watch` scripts
- **89 tests across 9 files**, all passing:
  - `config.test.ts` (20): Zod schema validation + `buildCreatePayload`
  - `fees.test.ts` (22): Fee calculation, surcharge tiers, formatting
  - `validate.test.ts` (9): `buildFeeOptions` mapper, X campaign regression
  - `constants.test.ts` (5): `campaignIdToBytes32`, `getRouterAddress`
  - `api.test.ts` (10): Mock fetch for all endpoints + retry exhaustion
  - `resume.test.ts` (5): Recovery file I/O roundtrip
  - `chain.test.ts` (7): Mocked viem clients for on-chain ops
  - `create.test.ts` (6): Command-level integration with mocked deps
  - `resume.command.test.ts` (5): Resume command integration

## T2 Traceability
| T2 Item | Resolution |
|---------|-----------|
| T2-1 A1: chain.test.ts | `tests/chain.test.ts` — 7 tests |
| T2-1 A2: terminal error + retry tests | `tests/api.test.ts` — 400/403/409 immediate throw + 202×7 exhaustion |
| T2-1 R1: X campaign actions regression | `tests/validate.test.ts` — P0-2 regression test |
| T2-1 P1: command-level integration | `tests/create.test.ts` + `tests/resume.command.test.ts` |
| T2-2 #1: integration tests | `tests/create.test.ts` + `tests/resume.command.test.ts` |
| T2-2 #5: behavioral verification | Dry-run without PRIVATE_KEY, --json valid output, wallet mismatch exits, recovery file on API failure |

## Test plan
- [x] `npm run test` — 89/89 pass
- [x] `npm run typecheck` — no errors
- [x] `npm run build` — clean
- [x] `node dist/index.js --help` — CLI works
- [x] `node dist/index.js validate --config examples/campaign.farcaster.pool-split.json --offline` — validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)