### PR TITLE
[#11] Align CLI docs/skill with created_via source-tagging contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ With `--execute`, the command:
 5. Registers the campaign via `POST /api/campaigns` (with automatic 202 retry)
 6. On success, deletes the recovery file and prints campaign details
 
+All API requests include the `X-Dropcast-Client: cli` header, which the backend uses to tag campaigns as `created_via='cli'`. This enables deterministic filtering of CLI-originated campaigns (e.g. the `/ai` page). Historical campaigns created before this tagging was deployed may have `created_via = NULL`.
+
 ### `resume`
 
 Resume a funded-but-unregistered campaign from its recovery file. Sends no on-chain transactions.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -13,6 +13,8 @@
 
 The CLI is installed locally in the project. Run via `npx dropcast-cli <command>` or the built binary.
 
+All API requests include the `X-Dropcast-Client: cli` header. The backend persists this as `campaigns.created_via = 'cli'`, enabling the `/ai` page to deterministically filter CLI-originated campaigns. Historical campaigns (created before source tagging was deployed) may have `created_via = NULL`; `NULL` is also expected for non-CLI creation paths (e.g. the web app).
+
 ## 2. Quick Defaults
 
 ```
@@ -87,7 +89,7 @@ dropcast-cli create --config campaign.json --execute --yes --json
 1. Approve the ERC-20 token spend (if allowance insufficient)
 2. Call `fundCampaign()` on the Router contract (sends tokens + ETH fee)
 3. Write a recovery file to `.dropcast-cli/<campaignId>.json`
-4. Register the campaign via `POST /api/campaigns` (with internal 202 retry)
+4. Register the campaign via `POST /api/campaigns` (with `X-Dropcast-Client: cli` header and internal 202 retry)
 5. On success, delete the recovery file and return the campaign details
 
 ### Step 6: Error recovery

--- a/skill/references/campaign-params.md
+++ b/skill/references/campaign-params.md
@@ -5,6 +5,12 @@
 
 ---
 
+## 0. Source Tagging
+
+All CLI API requests include the `X-Dropcast-Client: cli` header. The backend stores this as `campaigns.created_via = 'cli'`, which the `/ai` page uses for filtering. Historical campaigns may have `created_via = NULL` (pre-tagging); `NULL` is also the value for non-CLI paths. No agent action is required — the header is sent automatically by the CLI's HTTP client.
+
+---
+
 ## 1. Resolution Priority
 
 When building a campaign config from a user request, resolve each field in this order:

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -87,6 +87,36 @@ const STUB_PAYLOAD: CreateCampaignPayload = {
 
 // ── Tests ──
 
+describe('X-Dropcast-Client header', () => {
+  beforeEach(() => {
+    vi.stubEnv('DROPCAST_API_BASE_URL', 'https://test.dropcast.xyz')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+  })
+
+  it('sends X-Dropcast-Client: cli on every request', async () => {
+    mockFetch({ status: 200, json: { cast: { hash: '0x1', author: { fid: 1, username: 'a', display_name: 'A', pfp_url: '' }, text: '', embeds: [] } } })
+
+    await resolveCast('https://warpcast.com/a/0x1')
+
+    const callInit = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
+    expect((callInit.headers as Record<string, string>)['X-Dropcast-Client']).toBe('cli')
+  })
+
+  it('sends X-Dropcast-Client: cli on POST /api/campaigns', async () => {
+    mockFetch({ status: 201, json: { success: true, campaign: { id: STUB_PAYLOAD.id, campaign_number: 1, status: 'active' } } })
+
+    await createCampaign(STUB_PAYLOAD)
+
+    const callInit = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
+    expect((callInit.headers as Record<string, string>)['X-Dropcast-Client']).toBe('cli')
+  })
+})
+
 describe('resolveCast', () => {
   beforeEach(() => {
     vi.stubEnv('DROPCAST_API_BASE_URL', 'https://test.dropcast.xyz')


### PR DESCRIPTION
## Summary

- Document that CLI sends `X-Dropcast-Client: cli` header on all API requests (`src/api.ts:11`)
- Backend persists this as `campaigns.created_via = 'cli'`, enabling `/ai` page filtering
- Add caveat: historical campaigns may have `created_via = NULL` (pre-tagging); `NULL` is also expected for non-CLI paths
- Add 2 focused tests verifying the header is present on GET and POST API calls

## Changed Files

| File | Change |
|------|--------|
| `README.md` | Source-tagging paragraph in `create --execute` section |
| `skill/SKILL.md` | Header contract in Overview + Step 5 callout |
| `skill/references/campaign-params.md` | New Section 0: Source Tagging |
| `tests/api.test.ts` | 2 new tests: header on GET (resolveCast) and POST (createCampaign) |

## Verification

```bash
npm run build        # ✅ clean
npm run test         # ✅ 93 passed (91 existing + 2 new header tests)
```

## Caveats

- No runtime behavior changes — the `X-Dropcast-Client: cli` header was already being sent (`src/api.ts:11`); this PR only documents the contract and adds test coverage
- Historical campaigns created before backend source-tagging deployment have `created_via = NULL`
- Non-CLI creation paths (web app) also produce `NULL` — this is expected, not an error

Fixes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)