### PR TITLE
[#13] Migrate warpcast.com references to farcaster.xyz

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Campaign configs are JSON files validated against a Zod schema. See `examples/` 
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `url` | string (URL) | Yes | Warpcast URL (Farcaster) or tweet URL (X) |
+| `url` | string (URL) | Yes | Farcaster post URL or tweet URL (X) |
 
 ### `token`
 

--- a/examples/campaign.farcaster.fixed.json
+++ b/examples/campaign.farcaster.fixed.json
@@ -6,7 +6,7 @@
     "walletAddress": "0x0000000000000000000000000000000000000000"
   },
   "post": {
-    "url": "https://warpcast.com/bob/0xdef456"
+    "url": "https://farcaster.xyz/bob/0xdef456"
   },
   "token": {
     "address": "0x4ed4E862860beD51a9570b96d89aF5E1B0Efefed",

--- a/examples/campaign.farcaster.pool-split.json
+++ b/examples/campaign.farcaster.pool-split.json
@@ -6,7 +6,7 @@
     "walletAddress": "0x0000000000000000000000000000000000000000"
   },
   "post": {
-    "url": "https://warpcast.com/alice/0xabc123"
+    "url": "https://farcaster.xyz/alice/0xabc123"
   },
   "token": {
     "address": "0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB",

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -34,14 +34,14 @@ Follow these steps in order. **Never skip the dry-run.**
 
 The user's **post URL** is the primary required input. Parse the user's request and write a `campaign.json` file.
 
-- **Farcaster**: Use `skill/templates/campaign.farcaster.template.json` as the starting point. Resolve the cast from the Warpcast URL and **suggest** `host.fid` from `cast.author.fid` — confirm with user before using.
+- **Farcaster**: Use `skill/templates/campaign.farcaster.template.json` as the starting point. Resolve the cast from the Farcaster URL and **suggest** `host.fid` from `cast.author.fid` — confirm with user before using.
 - **X**: Use `skill/templates/campaign.x.template.json` as the starting point. `host.fid` must be asked or known from context (X posts don't carry FID).
 - **Token**: Default to USDC if the user doesn't specify a token.
 
 Fields the agent **must** replace from user/context:
 - `host.fid` -- the user's Farcaster FID (integer). For Farcaster campaigns, suggest from cast author; for X, must ask.
 - `host.walletAddress` -- the user's wallet address (0x...)
-- `post.url` -- the Warpcast or X post URL
+- `post.url` -- the Farcaster or X post URL
 - `schedule.endsAt` -- **must always be overwritten**. Compute as `now + 24h` by default, or from user input. The template uses `2099-12-31` as a placeholder — never submit this value.
 
 Fields the agent replaces **only if user specifies non-default values**:
@@ -195,7 +195,7 @@ Campaign configs must pass the Zod schema defined in `src/config.ts`. Brief fiel
 | `network` | `"base"` (literal) | Only Base Mainnet is supported |
 | `platform` | `"farcaster"` or `"x"` | Determines post resolution and action behavior |
 | `host` | `fid`, `walletAddress` | Must match `PRIVATE_KEY` wallet for `--execute` |
-| `post` | `url` | Warpcast URL (Farcaster) or tweet URL (X) |
+| `post` | `url` | Farcaster post URL or tweet URL (X) |
 | `token` | `address`, `symbol`, `decimals`, `logoUrl?` | ERC-20 on Base |
 | `reward` | `type` + type-specific fields | `pool_split`: `totalAmount`; `fixed`: `amountPerUser` + `maxParticipants` |
 | `actions` | `follow`, `like`, `recast`, `quote`, `comment` | Booleans. X campaigns ignore these (proof-of-read only) |

--- a/skill/references/campaign-params.md
+++ b/skill/references/campaign-params.md
@@ -31,7 +31,7 @@ When building a campaign config from a user request, resolve each field in this 
 | Field | Type | Required | Default | Resolution notes |
 |-------|------|----------|---------|------------------|
 | `network` | `"base"` (literal) | Yes | -- | Always `"base"`. DropCast only supports Base Mainnet (chain 8453). |
-| `platform` | `"farcaster" \| "x"` | Yes | -- | Infer from post URL domain. Warpcast = farcaster. x.com/twitter.com = x. |
+| `platform` | `"farcaster" \| "x"` | Yes | -- | Infer from post URL domain. farcaster.xyz = farcaster. x.com/twitter.com = x. |
 
 ### `host`
 
@@ -44,7 +44,7 @@ When building a campaign config from a user request, resolve each field in this 
 
 | Field | Type | Required | Default | Resolution notes |
 |-------|------|----------|---------|------------------|
-| `post.url` | string, valid URL | Yes | -- | Farcaster: Warpcast URL (e.g. `https://warpcast.com/user/0xhash`). X: tweet URL (e.g. `https://x.com/user/status/123`). |
+| `post.url` | string, valid URL | Yes | -- | Farcaster: `https://farcaster.xyz/user/0xhash`. X: `https://x.com/user/status/123`. |
 
 ### `token`
 

--- a/skill/templates/campaign.farcaster.template.json
+++ b/skill/templates/campaign.farcaster.template.json
@@ -6,7 +6,7 @@
     "walletAddress": "0x0000000000000000000000000000000000000000"
   },
   "post": {
-    "url": "https://warpcast.com/username/0xCastHash"
+    "url": "https://farcaster.xyz/username/0xCastHash"
   },
   "token": {
     "address": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",

--- a/src/create.ts
+++ b/src/create.ts
@@ -199,7 +199,7 @@ export async function createCommand(options: {
     const normalizedAddresses = verified_addresses.map(a => a.toLowerCase())
     if (!normalizedAddresses.includes(account.address.toLowerCase())) {
       const msg = `Wallet ${account.address} is not a verified address for FID ${config.host.fid}. ` +
-        `Connect it on Warpcast (Settings → Connected Addresses) and retry.`
+        `Connect it on Farcaster (Settings → Connected Addresses) and retry.`
       if (options.json) {
         jsonOutput({ error: msg, fid: config.host.fid, wallet: account.address, verified_addresses })
       } else {

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -101,7 +101,7 @@ describe('X-Dropcast-Client header', () => {
   it('sends X-Dropcast-Client: cli on every request', async () => {
     mockFetch({ status: 200, json: { cast: { hash: '0x1', author: { fid: 1, username: 'a', display_name: 'A', pfp_url: '' }, text: '', embeds: [] } } })
 
-    await resolveCast('https://warpcast.com/a/0x1')
+    await resolveCast('https://farcaster.xyz/a/0x1')
 
     const callInit = (fetch as ReturnType<typeof vi.fn>).mock.calls[0][1] as RequestInit
     expect((callInit.headers as Record<string, string>)['X-Dropcast-Client']).toBe('cli')
@@ -137,7 +137,7 @@ describe('resolveCast', () => {
     }
     mockFetch({ status: 200, json: { cast: castData } })
 
-    const result = await resolveCast('https://warpcast.com/alice/0xabc')
+    const result = await resolveCast('https://farcaster.xyz/alice/0xabc')
 
     expect(result).toEqual(castData)
     expect(fetch).toHaveBeenCalledOnce()
@@ -153,8 +153,8 @@ describe('resolveCast', () => {
       statusText: 'Not Found',
     })
 
-    await expect(resolveCast('https://warpcast.com/alice/0xbad')).rejects.toThrow(ApiError)
-    await expect(resolveCast('https://warpcast.com/alice/0xbad')).rejects.toThrow(/Failed to resolve cast/)
+    await expect(resolveCast('https://farcaster.xyz/alice/0xbad')).rejects.toThrow(ApiError)
+    await expect(resolveCast('https://farcaster.xyz/alice/0xbad')).rejects.toThrow(/Failed to resolve cast/)
   })
 })
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -23,7 +23,7 @@ function validFarcasterFixed(): Record<string, unknown> {
       fid: 1,
       walletAddress: '0x0000000000000000000000000000000000000001',
     },
-    post: { url: 'https://warpcast.com/alice/0xabc123' },
+    post: { url: 'https://farcaster.xyz/alice/0xabc123' },
     token: {
       address: '0x0000000000000000000000000000000000000002',
       symbol: 'TKN',

--- a/tests/resume.command.test.ts
+++ b/tests/resume.command.test.ts
@@ -74,7 +74,7 @@ function makeRecoveryData(overrides: Record<string, unknown> = {}) {
         walletAddress: '0x0000000000000000000000000000000000000000',
       },
       post: {
-        url: 'https://warpcast.com/alice/0xabc123',
+        url: 'https://farcaster.xyz/alice/0xabc123',
       },
       token: {
         address: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB',

--- a/tests/resume.test.ts
+++ b/tests/resume.test.ts
@@ -29,7 +29,7 @@ const STUB_RECOVERY: RecoveryData = {
       walletAddress: '0x0000000000000000000000000000000000000000',
     },
     post: {
-      url: 'https://warpcast.com/alice/0xabc123',
+      url: 'https://farcaster.xyz/alice/0xabc123',
     },
     token: {
       address: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB',

--- a/tests/validate.test.ts
+++ b/tests/validate.test.ts
@@ -20,7 +20,7 @@ function makeConfig(overrides: {
       fid: 1,
       walletAddress: '0x0000000000000000000000000000000000000001',
     },
-    post: { url: 'https://warpcast.com/alice/0xabc123' },
+    post: { url: 'https://farcaster.xyz/alice/0xabc123' },
     token: {
       address: '0x0000000000000000000000000000000000000002',
       symbol: 'TKN',


### PR DESCRIPTION
## Summary

- Replace all `warpcast.com` URLs with `farcaster.xyz` across the entire codebase
- Update "Warpcast" product name to "Farcaster" in user-facing error message (`src/create.ts:202`)
- No behavioral changes — URL validation uses `z.string().url()` (domain-agnostic) and `resolveCast` passes URLs directly to Neynar API

## Changed Files (12)

| File | Change |
|------|--------|
| `src/create.ts` | Error message: "Connect it on Farcaster" |
| `README.md` | "Farcaster post URL" in post field description |
| `skill/SKILL.md` | 3 refs: Step 1, post.url field, config schema table |
| `skill/references/campaign-params.md` | 2 refs: platform resolution, post.url example |
| `skill/templates/campaign.farcaster.template.json` | Template URL placeholder |
| `examples/campaign.farcaster.pool-split.json` | Example URL |
| `examples/campaign.farcaster.fixed.json` | Example URL |
| `tests/api.test.ts` | 4 test URL refs |
| `tests/config.test.ts` | 1 test URL ref |
| `tests/validate.test.ts` | 1 test URL ref |
| `tests/resume.test.ts` | 1 test URL ref |
| `tests/resume.command.test.ts` | 1 test URL ref |

## Verification

```bash
grep -r "warpcast" --include="*.ts" --include="*.md" --include="*.json" .  # zero matches
npm run build   # ✅ clean
npm run test    # ✅ 93/93 passed
# Templates fail only on host.fid: 0 (expected)
```

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)