### PR TITLE
[#18] Reset stale ERC-20 allowance before approving

### DIFF
--- a/src/chain.ts
+++ b/src/chain.ts
@@ -172,6 +172,26 @@ export async function fundCampaign(params: {
   let approvalTxHash: `0x${string}` | undefined
 
   if (currentAllowance < params.tokenAmount) {
+    // Reset allowance to 0 first if non-zero — required by USDC and other tokens
+    // that revert on approve(spender, newAmount) when current allowance is non-zero.
+    if (currentAllowance > 0n) {
+      const resetData = encodeFunctionData({
+        abi: ERC20_ABI,
+        functionName: 'approve',
+        args: [routerAddress, 0n],
+      })
+
+      const resetHash = await walletClient.sendTransaction({
+        account,
+        to: params.tokenAddress,
+        data: resetData,
+        value: 0n,
+        chain: baseChain,
+      })
+
+      await publicClient.waitForTransactionReceipt({ hash: resetHash })
+    }
+
     const approveData = encodeFunctionData({
       abi: ERC20_ABI,
       functionName: 'approve',

--- a/tests/chain.test.ts
+++ b/tests/chain.test.ts
@@ -100,14 +100,13 @@ describe('fundCampaign', () => {
     expect(mockSimulateContract).toHaveBeenCalledOnce()
   })
 
-  it('approves first when allowance is insufficient', async () => {
-    // Allowance < tokenAmount
-    mockReadContract.mockResolvedValueOnce(100n) // allowance (too low)
-    // Approve tx
-    mockWriteContract.mockResolvedValueOnce('0xapprove_hash')
+  it('approves first when allowance is insufficient (with non-zero reset)', async () => {
+    // Allowance < tokenAmount and non-zero — triggers reset-to-0 then approve
+    mockReadContract.mockResolvedValueOnce(100n) // allowance (too low, non-zero)
     mockSendTransaction
-      .mockResolvedValueOnce('0xapprove_hash') // approve tx
-      .mockResolvedValueOnce('0xfund_hash') // fund tx
+      .mockResolvedValueOnce('0xreset_hash')   // approve(router, 0)
+      .mockResolvedValueOnce('0xapprove_hash') // approve(router, amount)
+      .mockResolvedValueOnce('0xfund_hash')    // fund tx
 
     const result = await fundCampaign({
       tokenAddress: '0xe8f5314e8DBE7EA9978190eC243f7b4258eaD7FB' as `0x${string}`,
@@ -116,10 +115,52 @@ describe('fundCampaign', () => {
       feeAmountWei: 1000000000000000n,
     })
 
-    expect(result.approvalTxHash).toBeDefined()
-    expect(result.txHash).toBeDefined()
-    // waitForTransactionReceipt should have been called (for approval at least)
+    expect(result.approvalTxHash).toBe('0xapprove_hash')
+    expect(result.txHash).toBe('0xfund_hash')
+    // 3 sends: reset, approve, fund
+    expect(mockSendTransaction).toHaveBeenCalledTimes(3)
     expect(mockWaitForTransactionReceipt).toHaveBeenCalled()
+  })
+
+  it('resets allowance to 0 before approving when stale non-zero allowance exists', async () => {
+    // Stale allowance: non-zero but less than required (e.g. leftover from previous campaign)
+    mockReadContract.mockResolvedValueOnce(8000000n) // stale allowance (8 USDC)
+    mockSendTransaction
+      .mockResolvedValueOnce('0xreset_hash')   // approve(router, 0)
+      .mockResolvedValueOnce('0xapprove_hash') // approve(router, amount)
+      .mockResolvedValueOnce('0xfund_hash')    // fundCampaign tx
+
+    const result = await fundCampaign({
+      tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as `0x${string}`,
+      tokenAmount: 12000000n, // 12 USDC — more than stale 8 USDC
+      campaignId: '550e8400-e29b-41d4-a716-446655440000',
+      feeAmountWei: 1000000000000000n,
+    })
+
+    // 3 sendTransaction calls: reset-to-0, approve, fund
+    expect(mockSendTransaction).toHaveBeenCalledTimes(3)
+    expect(result.approvalTxHash).toBe('0xapprove_hash')
+    expect(result.txHash).toBe('0xfund_hash')
+  })
+
+  it('skips reset when allowance is already 0', async () => {
+    // Allowance is 0 — no reset needed, just approve
+    mockReadContract.mockResolvedValueOnce(0n)
+    mockSendTransaction
+      .mockResolvedValueOnce('0xapprove_hash') // approve(router, amount)
+      .mockResolvedValueOnce('0xfund_hash')    // fundCampaign tx
+
+    const result = await fundCampaign({
+      tokenAddress: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as `0x${string}`,
+      tokenAmount: 12000000n,
+      campaignId: '550e8400-e29b-41d4-a716-446655440000',
+      feeAmountWei: 1000000000000000n,
+    })
+
+    // 2 sendTransaction calls: approve, fund (no reset)
+    expect(mockSendTransaction).toHaveBeenCalledTimes(2)
+    expect(result.approvalTxHash).toBe('0xapprove_hash')
+    expect(result.txHash).toBe('0xfund_hash')
   })
 
   it('propagates simulation failure without sending real tx', async () => {


### PR DESCRIPTION
## Summary

- Fix `SafeERC20FailedOperation` revert when a stale non-zero ERC-20 allowance exists on the Router
- USDC (and similar tokens) require allowance to be reset to 0 before setting a new value
- Discovered during live test of PR #17 — campaign #181 execute failed on first attempt

## Changes

- **`src/chain.ts`**: In `fundCampaign()`, when `currentAllowance > 0` but insufficient, send `approve(router, 0)` before `approve(router, amount)`
- **`tests/chain.test.ts`**: 2 new tests (stale allowance reset, zero allowance skip), 1 existing test updated for new 3-tx flow

## Test plan

- [x] `npm run build` — clean
- [x] `npm run test` — 106 tests pass
- [ ] Live: create campaign after a previous campaign left stale allowance

Fixes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)